### PR TITLE
Fix Diffusers Demo in README.md to avoid pipe and encoder having different dtypes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ pipe = HiDreamImagePipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
 )
 
-pipe = pipe.to('cuda')
+pipe = pipe.to('cuda', dtype=torch.bfloat16)
 
 image = pipe(
     'A cat holding a sign that says "HiDream.ai".',


### PR DESCRIPTION
As the title says.

When I tried running the `diffusers` demo code, I got the following error and was able to resolve it by correctly setting the `dtype` for `pipe` as well:
```
2025-04-25 09:37:15,109 ERROR main expected mat1 and mat2 to have the same dtype, but got: c10::Half != c10::BFloat16
Traceback (most recent call last):
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/LlavaGuard/src/experiments/safety_benchmark_models/hidream-i1-full/entrypoint_generate_images.py", line 56, in generate_images
image = pipe(
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/envs/sglang/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
return func(*args, **kwargs)
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/envs/sglang/lib/python3.10/site-packages/diffusers/pipelines/hidream_image/pipeline_hidream_image.py", line 887, in call
) = self.encode_prompt(
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/envs/sglang/lib/python3.10/site-packages/diffusers/pipelines/hidream_image/pipeline_hidream_image.py", line 339, in encode_prompt
pooled_prompt_embeds_1 = self._get_clip_prompt_embeds(
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/envs/sglang/lib/python3.10/site-packages/diffusers/pipelines/hidream_image/pipeline_hidream_image.py", line 256, in _get_clip_prompt_embeds
prompt_embeds = text_encoder(text_input_ids.to(device), output_hidden_states=True)
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/envs/sglang/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
return self._call_impl(*args, **kwargs)
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/envs/sglang/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
return forward_call(*args, **kwargs)
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/envs/sglang/lib/python3.10/site-packages/transformers/models/clip/modeling_clip.py", line 1490, in forward
text_embeds = self.text_projection(pooled_output)
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/envs/sglang/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
return self._call_impl(*args, **kwargs)
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/envs/sglang/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
return forward_call(*args, **kwargs)
File "/pfss/mlde/workspaces/mlde_wsp_KIServiceCenter/finngu/envs/sglang/lib/python3.10/site-packages/torch/nn/modules/linear.py", line 125, in forward
return F.linear(input, self.weight, self.bias)
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::Half != c10::BFloat16
```