### PR TITLE
fix img size shape mismatch error when using fast model

### DIFF
--- a/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py
+++ b/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py
@@ -629,6 +629,9 @@ class HiDreamImagePipeline(DiffusionPipeline, FromSingleFileMixin):
             if self.do_classifier_free_guidance:
                 img_sizes = img_sizes.repeat(2 * B, 1)
                 img_ids = img_ids.repeat(2 * B, 1, 1)
+            else:
+                img_sizes = img_sizes.repeat(B, 1)
+                img_ids = img_ids.repeat(B, 1, 1)
         else:
             img_sizes = img_ids = None
 


### PR DESCRIPTION
For the fast and dev model, guidance_scale is set to zero in MODEL_CONFIGS. When using these two models to generate multiple images(num_images_per_prompt > 1) and setting height != width, shape mismatch error will happen. This PR fix this error.